### PR TITLE
VGS-65-fix-blogs

### DIFF
--- a/src/controllers/projects.ts
+++ b/src/controllers/projects.ts
@@ -311,6 +311,7 @@ export const projectsController = {
             as: "board",
           },
         ],
+        order: [[{ model: Blog, as: "blogs" }, "createdAt", "DESC"]],
       });
 
       response.status_code = STATUS_CODE_OK;


### PR DESCRIPTION
Changed the order of the blogs retrieved by the GET project by id endpoint. Now the most recently blog is retrieved first.