### PR TITLE
VGS-78-fix-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - "dev"
-      - "dev2"
       - "main"
 
 jobs:


### PR DESCRIPTION
Branch 'dev2' was deleted so thee rule in ci.yml for that branch was also deleted.